### PR TITLE
bug_fixed_datetime displayed in the timezone of the app's user

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -18,11 +18,11 @@ import {
   Link,
   Stack,
   AspectRatioBox,
-  StatGroup,
+  StatGroup, Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import {formatDateTime, getTimeZoneName} from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -124,7 +124,9 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip label={formatDateTime(launch.launch_date_local)} aria-label='user timezone'>
+            {formatDateTime(launch.launch_date_local,getTimeZoneName(launch.launch_date_local))}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,3 +1,5 @@
+import { timeZones } from "./timezones";
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",
@@ -7,7 +9,7 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
+export function formatDateTime(timestamp, timeZone = undefined ) {
   return new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
@@ -16,5 +18,21 @@ export function formatDateTime(timestamp) {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
+    timeZone
   }).format(new Date(timestamp));
+}
+
+/**
+ * Given a timezone calculate the offset and search in timezone array the name for that timezone
+ * @param {String} timezone
+ * @return {String} timeZoneName
+ */
+export const getTimeZoneName = (timezone)=> {
+  const isPositive = (timezone.includes("+"));
+  const timeZoneNumber = (isPositive)?timezone.split("+"):timezone.split("-");
+  const createTZNumber = (isPositive)?`+${timeZoneNumber[timeZoneNumber.length-1]}`:`-${timeZoneNumber[timeZoneNumber.length-1]}`
+  const timeZoneName = timeZones.find((e)=>  {
+    return e.UTC_offset === createTZNumber}
+  )
+  return (timeZoneName)?timeZoneName.TZ_database_name : null;
 }

--- a/src/utils/timezones.js
+++ b/src/utils/timezones.js
@@ -1,0 +1,622 @@
+export const timeZones= [
+  {
+    "Country_code": "",
+    "TZ_database_name": "Etc/GMT+12",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "-12:00",
+    "UTC_DST_offset": "-12:00",
+    "Source_File": "etcetera",
+    "Notes": "Sign is intentionally inverted. See the Etc area description"
+  },
+  {
+    "Country_code": "",
+    "TZ_database_name": "Etc/GMT+11",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "-11:00",
+    "UTC_DST_offset": "-11:00",
+    "Source_File": "etcetera",
+    "Notes": "Sign is intentionally inverted. See the Etc area description"
+  },
+  {
+    "Country_code": "UM",
+    "TZ_database_name": "Pacific/Midway",
+    "Area_covered": "Midway Islands",
+    "Type": "Link",
+    "UTC_offset": "-11:00",
+    "UTC_DST_offset": "-11:00",
+    "Source_File": "australasia",
+    "Notes": "Link to Pacific/Pago_Pago"
+  },
+  {
+    "Country_code": "NU",
+    "TZ_database_name": "Pacific/Niue",
+    "Area_covered": "Canonical",
+    "Type": "Canonical",
+    "UTC_offset": "-11:00",
+    "UTC_DST_offset": "-11:00",
+    "Source_File": "australasia",
+    "Notes": "Link to Pacific/Pago_Pago"
+  },
+  {
+    "Country_code": "NU",
+    "TZ_database_name": "Pacific/Niue",
+    "Area_covered": "Canonical",
+    "Type": "Canonical",
+    "UTC_offset": "-11:00",
+    "UTC_DST_offset": "-11:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AS,UM",
+    "TZ_database_name": "Pacific/Pago_Pago",
+    "Area_covered": "Samoa, Midway",
+    "Type": "Canonical",
+    "UTC_offset": "-11:00",
+    "UTC_DST_offset": "-11:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AS,UM",
+    "TZ_database_name": "Pacific/Pago_Pago",
+    "Area_covered": "Samoa, Midway",
+    "Type": "Canonical",
+    "UTC_offset": "-11:00",
+    "UTC_DST_offset": "-11:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "US",
+    "TZ_database_name": "America/Adak",
+    "Area_covered": "Aleutian Islands",
+    "Type": "Canonical",
+    "UTC_offset": "-10:00",
+    "UTC_DST_offset": "-09:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "US,UM",
+    "TZ_database_name": "Pacific/Honolulu",
+    "Area_covered": "Hawaii",
+    "Type": "Canonical",
+    "UTC_offset": "-10:00",
+    "UTC_DST_offset": "-10:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PF",
+    "TZ_database_name": "Pacific/Marquesas",
+    "Area_covered": "Marquesas Islands",
+    "Type": "Canonical",
+    "UTC_offset": "-09:30",
+    "UTC_DST_offset": "-09:30",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PF",
+    "TZ_database_name": "America/Nome",
+    "Area_covered": "Alaska (west)",
+    "Type": "Canonical",
+    "UTC_offset": "-09:00",
+    "UTC_DST_offset": "-08:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PF",
+    "TZ_database_name": "Pacific/Gambier",
+    "Area_covered": "Gambier Islands",
+    "Type": "Canonical",
+    "UTC_offset": "-09:00",
+    "UTC_DST_offset": "-09:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PF",
+    "TZ_database_name": "Pacific/Gambier",
+    "Area_covered": "Gambier Islands",
+    "Type": "Canonical",
+    "UTC_offset": "-09:00",
+    "UTC_DST_offset": "-09:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "US",
+    "TZ_database_name": "America/Los_Angeles",
+    "Area_covered": "Pacific",
+    "Type": "Canonical",
+    "UTC_offset": "-08:00",
+    "UTC_DST_offset": "-07:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PN",
+    "TZ_database_name": "Pacific/Pitcairn",
+    "Area_covered": "Pacific",
+    "Type": "Canonical",
+    "UTC_offset": "-08:00",
+    "UTC_DST_offset": "-08:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "US,CA",
+    "TZ_database_name": "America/Phoenix",
+    "Area_covered": "MST - Arizona (except Navajo), Creston BC",
+    "Type": "Canonical",
+    "UTC_offset": "-07:00",
+    "UTC_DST_offset": "-07:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "CA",
+    "TZ_database_name": "America/Yellowknife",
+    "Area_covered": "Mountain - NT (central)",
+    "Type": "Canonical",
+    "UTC_offset": "-07:00",
+    "UTC_DST_offset": "-06:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "BZ",
+    "TZ_database_name": "America/Belize",
+    "Area_covered": "Mountain - NT (central)",
+    "Type": "Canonical",
+    "UTC_offset": "-06:00",
+    "UTC_DST_offset": "-06:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "US",
+    "TZ_database_name": "America/Chicago",
+    "Area_covered": "Central (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "-06:00",
+    "UTC_DST_offset": "-05:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "CO",
+    "TZ_database_name": "America/Bogota",
+    "Area_covered": "Central (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "-05:00",
+    "UTC_DST_offset": "-05:00",
+    "Source_File": "southamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "CU",
+    "TZ_database_name": "America/Havana",
+    "Area_covered": "Central (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "-05:00",
+    "UTC_DST_offset": "-04:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "VE",
+    "TZ_database_name": "America/Caracas",
+    "Area_covered": "Central (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "-04:00",
+    "UTC_DST_offset": "-04:00",
+    "Source_File": "southamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PY",
+    "TZ_database_name": "America/Asuncion",
+    "Area_covered": "Central (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "-04:00",
+    "UTC_DST_offset": "-03:00",
+    "Source_File": "southamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "CA",
+    "TZ_database_name": "America/St_Johns",
+    "Area_covered": "Newfoundland; Labrador (southeast)",
+    "Type": "Canonical",
+    "UTC_offset": "-03:30",
+    "UTC_DST_offset": "-02:30",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "UY",
+    "TZ_database_name": "America/Montevideo",
+    "Area_covered": "Buenos Aires (BA, CF)",
+    "Type": "Canonical",
+    "UTC_offset": "-03:00",
+    "UTC_DST_offset": "-03:00",
+    "Source_File": "southamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PM",
+    "TZ_database_name": "America/Miquelon",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "-03:00",
+    "UTC_DST_offset": "-02:00",
+    "Source_File": "northamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "BR",
+    "TZ_database_name": "America/Noronha",
+    "Area_covered": "Atlantic islands",
+    "Type": "Canonical",
+    "UTC_offset": "-02:00",
+    "UTC_DST_offset": "-02:00",
+    "Source_File": "southamerica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "CV",
+    "TZ_database_name": "Atlantic/Cape_Verde",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "-01:00",
+    "UTC_DST_offset": "-01:00",
+    "Source_File": "africa",
+    "Notes": ""
+  },
+  {
+    "Country_code": "PT",
+    "TZ_database_name": "Atlantic/Azores",
+    "Area_covered": "Azores",
+    "Type": "Canonical",
+    "UTC_offset": "-01:00",
+    "UTC_DST_offset": "+00:00",
+    "Source_File": "europe",
+    "Notes": ""
+  },
+  {
+    "Country_code": "CI,BF,GH,GM,GN,ML,MR,SH,SL,SN,TG",
+    "TZ_database_name": "Africa/Abidjan",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+00:00",
+    "UTC_DST_offset": "+00:00",
+    "Source_File": "africa",
+    "Notes": ""
+  },
+  {
+    "Country_code": "ES",
+    "TZ_database_name": "Atlantic/Canary",
+    "Area_covered": "Canary Islands",
+    "Type": "Canonical",
+    "UTC_offset": "+00:00",
+    "UTC_DST_offset": "+01:00",
+    "Source_File": "europe",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AQ",
+    "TZ_database_name": "Antarctica/Troll",
+    "Area_covered": "Troll",
+    "Type": "Canonical",
+    "UTC_offset": "+00:00",
+    "UTC_DST_offset": "+02:00",
+    "Source_File": "antarctica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "MA",
+    "TZ_database_name": "Africa/Casablanca",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+01:00",
+    "UTC_DST_offset": "+00:00",
+    "Source_File": "africa",
+    "Notes": ""
+  },
+  {
+    "Country_code": "NG,AO,BJ,CD,CF,CG,CM,GA,GQ,NE",
+    "TZ_database_name": "Africa/Lagos",
+    "Area_covered": "West Africa Time",
+    "Type": "Canonical",
+    "UTC_offset": "+01:00",
+    "UTC_DST_offset": "+01:00",
+    "Source_File": "africa",
+    "Notes": ""
+  },
+  {
+    "Country_code": "DE",
+    "TZ_database_name": "Europe/Berlin",
+    "Area_covered": "Germany (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+01:00",
+    "UTC_DST_offset": "+02:00",
+    "Source_File": "europe",
+    "Notes": ""
+  },
+  {
+    "Country_code": "EG",
+    "TZ_database_name": "Africa/Cairo",
+    "Area_covered": "Germany (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+02:00",
+    "UTC_DST_offset": "+02:00",
+    "Source_File": "africa",
+    "Notes": ""
+  },
+  {
+    "Country_code": "UA",
+    "TZ_database_name": "Europe/Kiev",
+    "Area_covered": "Ukraine (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+02:00",
+    "UTC_DST_offset": "+03:00",
+    "Source_File": "europe",
+    "Notes": ""
+  },
+  {
+    "Country_code": "KE,DJ,ER,ET,KM,MG,SO,TZ,UG,YT",
+    "TZ_database_name": "Africa/Nairobi",
+    "Area_covered": "Ukraine (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+03:00",
+    "UTC_DST_offset": "+03:00",
+    "Source_File": "africa",
+    "Notes": ""
+  },
+  {
+    "Country_code": "IR",
+    "TZ_database_name": "Asia/Tehran",
+    "Area_covered": "Ukraine (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+03:30",
+    "UTC_DST_offset": "+04:30",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "RE,TF",
+    "TZ_database_name": "Indian/Reunion",
+    "Area_covered": "Réunion, Crozet, Scattered Islands",
+    "Type": "Canonical",
+    "UTC_offset": "+04:00",
+    "UTC_DST_offset": "+04:00",
+    "Source_File": "africa",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AF",
+    "TZ_database_name": "Asia/Kabul",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+04:30",
+    "UTC_DST_offset": "+04:30",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "MV",
+    "TZ_database_name": "Indian/Maldives",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+05:00",
+    "UTC_DST_offset": "+05:00",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "IN",
+    "TZ_database_name": "Asia/Kolkata",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+05:30",
+    "UTC_DST_offset": "+05:30",
+    "Source_File": "asia",
+    "Notes": "Different zones in history, see Time in India."
+  },
+  {
+    "Country_code": "NP",
+    "TZ_database_name": "Asia/Kathmandu",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+05:45",
+    "UTC_DST_offset": "+05:45",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AQ",
+    "TZ_database_name": "Antarctica/Vostok",
+    "Area_covered": "Vostok",
+    "Type": "Canonical",
+    "UTC_offset": "+06:00",
+    "UTC_DST_offset": "+06:00",
+    "Source_File": "antarctica",
+    "Notes": ""
+  },
+  {
+    "Country_code": "MM",
+    "TZ_database_name": "Asia/Yangon",
+    "Area_covered": "Vostok",
+    "Type": "Canonical",
+    "UTC_offset": "+06:30",
+    "UTC_DST_offset": "+06:30",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "TH,KH,LA,VN",
+    "TZ_database_name": "Asia/Bangkok",
+    "Area_covered": "Indochina (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+07:00",
+    "UTC_DST_offset": "+07:00",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "HK",
+    "TZ_database_name": "Asia/Hong_Kong",
+    "Area_covered": "Indochina (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+08:00",
+    "UTC_DST_offset": "+08:00",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AU",
+    "TZ_database_name": "Australia/Eucla",
+    "Area_covered": "Western Australia (Eucla)",
+    "Type": "Canonical",
+    "UTC_offset": "+08:45",
+    "UTC_DST_offset": "+08:45",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "JP",
+    "TZ_database_name": "Asia/Tokyo",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+09:00",
+    "UTC_DST_offset": "+09:00",
+    "Source_File": "asia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AU",
+    "TZ_database_name": "Australia/Darwin",
+    "Area_covered": "Northern Territory",
+    "Type": "Canonical",
+    "UTC_offset": "+09:30",
+    "UTC_DST_offset": "+09:30",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AU",
+    "TZ_database_name": "Australia/Adelaide",
+    "Area_covered": "South Australia",
+    "Type": "Canonical",
+    "UTC_offset": "+09:30",
+    "UTC_DST_offset": "+10:30",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AU",
+    "TZ_database_name": "Australia/Adelaide",
+    "Area_covered": "South Australia",
+    "Type": "Canonical",
+    "UTC_offset": "+09:30",
+    "UTC_DST_offset": "+10:30",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AU",
+    "TZ_database_name": "Australia/Brisbane",
+    "Area_covered": "Queensland (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+10:00",
+    "UTC_DST_offset": "+10:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AU",
+    "TZ_database_name": "Australia/Sydney",
+    "Area_covered": "New South Wales (most areas)",
+    "Type": "Canonical",
+    "UTC_offset": "+10:00",
+    "UTC_DST_offset": "+11:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "AU",
+    "TZ_database_name": "Australia/Lord_Howe",
+    "Area_covered": "Lord Howe Island",
+    "Type": "Canonical",
+    "UTC_offset": "+10:30",
+    "UTC_DST_offset": "+11:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "FM",
+    "TZ_database_name": "Pacific/Kosrae",
+    "Area_covered": "Kosrae",
+    "Type": "Canonical",
+    "UTC_offset": "+11:00",
+    "UTC_DST_offset": "+11:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "NF",
+    "TZ_database_name": "Pacific/Norfolk",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+11:00",
+    "UTC_DST_offset": "+12:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "FJ",
+    "TZ_database_name": "Pacific/Fiji",
+    "Area_covered": "",
+    "Type": "Canonical",
+    "UTC_offset": "+12:00",
+    "UTC_DST_offset": "+12:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "NZ",
+    "TZ_database_name": "Pacific/Chatham",
+    "Area_covered": "Chatham Islands",
+    "Type": "Canonical",
+    "UTC_offset": "+12:45",
+    "UTC_DST_offset": "+12:45",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "KI",
+    "TZ_database_name": "Pacific/Kanton",
+    "Area_covered": "Phoenix Islands",
+    "Type": "Canonical",
+    "UTC_offset": "+13:00",
+    "UTC_DST_offset": "+13:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  },
+  {
+    "Country_code": "KI",
+    "TZ_database_name": "Pacific/Kiritimati",
+    "Area_covered": "Line Islands",
+    "Type": "Canonical",
+    "UTC_offset": "+14:00",
+    "UTC_DST_offset": "+14:00",
+    "Source_File": "australasia",
+    "Notes": ""
+  }
+]


### PR DESCRIPTION
## Description:
The team discovered that the launch datetime on the launch details page (e.g. /launches/92) is displayed in the timezone of the app's user. However, the intent was to show it in the local timezone of the launch site instead (still displaying the timezone name or offset). After a discussion the team decided to make the change, but keep the time in the user's timezone as a tooltip when hovering the timestamp. You pick up that ticket.
## Rally stories and/or Jira tickets:
none
## How Has This Been Tested:
manual test
## Reviewers:
pending
## PR Dependencies:
-
## Screenshots:
![Space·Rockets_bug_timezone](https://user-images.githubusercontent.com/2244503/156591112-0a25de75-5588-4db5-88eb-0c2b584518f0.gif)

## New Tech Debt (create JIRA tickets):